### PR TITLE
Black and isort diff plugins

### DIFF
--- a/linthell/plugins/black_diff.py
+++ b/linthell/plugins/black_diff.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum
+from pathlib import Path
 from typing import List, Optional
 
 from typing_extensions import assert_never
@@ -162,7 +163,6 @@ class LinthellBlackDiffPlugin(LinthellPlugin):
                     if line.startswith(_REMOVE_LINE_SIGN)
                     else _FileVersion.NEW
                 )
-
                 self._append_errors(line=line, file_version=file_version)
                 self._incr_line_num(line=line, file_version=file_version)
             elif line.startswith(_KEEP_LINE_SIGN):
@@ -209,7 +209,7 @@ class LinthellBlackDiffPlugin(LinthellPlugin):
 
         self.errors.append(
             LinterError(
-                id_line=f'{self.file_path}:{line}',
+                id_line=f'{Path(self.file_path).as_posix()}:{line}',
                 error_message=f'{self.file_path}:{line_number}: {line}',
             ),
         )

--- a/linthell/plugins/black_diff.py
+++ b/linthell/plugins/black_diff.py
@@ -14,8 +14,8 @@ _FILE_PATH_PATTERN = re.compile(r'(?:-{3}|\+{3})\s(?P<file_path>[\w/.-]+).*')
 """Example: --- package/module.py 2023-08-24 09:29:48.256318 +0000"""
 _LINE_NUMBER_SIGN = '@'
 _LINE_NUMBER_PATTERN = re.compile(
-    r'@@ -(?P<old_file_version_line_number>\d+),\d+'
-    r' \+(?P<new_file_version_line_number>\d+),\d+ @@'
+    r'@@ -(?P<old_file_version_line_number>\d+)(,\d+)?'
+    r' \+(?P<new_file_version_line_number>\d+)(,\d+)? @@'
 )
 """Example: @@ -10,20 +10,20 @@"""
 _REMOVE_LINE_SIGN = '-'

--- a/linthell/plugins/black_diff.py
+++ b/linthell/plugins/black_diff.py
@@ -1,0 +1,238 @@
+import re
+from enum import Enum
+from typing import List, Optional
+
+from typing_extensions import assert_never
+
+from linthell.plugins.base import LinthellPlugin
+from linthell.utils.types import LinterError
+
+_OLD_VERSION_FILE_PATH_SIGN = '--- '
+_NEW_VERSION_FILE_PATH_SIGN = '+++ '
+_FILE_PATH_SIGNS = (_OLD_VERSION_FILE_PATH_SIGN, _NEW_VERSION_FILE_PATH_SIGN)
+_FILE_PATH_PATTERN = re.compile(r'(?:-{3}|\+{3})\s(?P<file_path>[\w/.-]+).*')
+"""Example: --- package/module.py 2023-08-24 09:29:48.256318 +0000"""
+_LINE_NUMBER_SIGN = '@'
+_LINE_NUMBER_PATTERN = re.compile(
+    r'@@ -(?P<old_file_version_line_number>\d+),\d+'
+    r' \+(?P<new_file_version_line_number>\d+),\d+ @@'
+)
+"""Example: @@ -10,20 +10,20 @@"""
+_REMOVE_LINE_SIGN = '-'
+"""Example: -    def_param: bool = True"""
+_ADD_LINE_SIGN = '+'
+"""Example: +    def_param: bool = True,"""
+_KEEP_LINE_SIGN = ' '
+"""Example:      def_param: bool = True,"""
+
+
+class _FileVersion(Enum):
+    """Enumeration of file versions represented in black output."""
+
+    OLD = 'old'
+    NEW = 'new'
+
+
+class BlackOutputInvalidError(Exception):
+    """Base error of invalid black-diff output.
+
+    Used to encapsulate logic of building an error message.
+    Allows to set `DEFAULT_MSG` for subclasses.
+    """
+
+    DEFAULT_MSG: str = 'no detail'
+
+    def __init__(self, line: str, msg: Optional[str] = None) -> None:
+        """Initialize exception instance.
+
+        :param line: line of black-diff output.
+        :param msg: verbose message of error.
+                    If not passed `self.DEFAULT_MSG` is used.
+        """
+        self.line = line
+        self.msg = msg or self.DEFAULT_MSG
+
+    def __str__(self):
+        return f'Invalid black-diff output ({self.msg}): {self.line}'
+
+
+class BlackOutputInvalidFilePathLineError(BlackOutputInvalidError):
+    """Error of black-diff output. Invalid line with file path.
+
+    Raised if line expected to contain file path but doesn't match pattern.
+    """
+
+    DEFAULT_MSG = (
+        'expected line to contain file path '
+        'but it does not match expected pattern'
+    )
+
+
+class BlackOutputInvalidLineNumberLineError(BlackOutputInvalidError):
+    """Error of black-diff output. Invalid line with line numbers.
+
+    Raised if line expected to contain line numbers but doesn't match pattern.
+    """
+
+    DEFAULT_MSG = (
+        'expected line to contain line number '
+        'but it does not match expected pattern'
+    )
+
+
+class BlackOutputInvalidLineOrderError(BlackOutputInvalidError):
+    """Error of black-diff output. Invalid line order.
+
+    Raised if expected to face lines with file path and line numbers before
+    current in-process line.
+    """
+
+    DEFAULT_MSG = (
+        'expected lines with file path and line number before lines with code'
+    )
+
+
+class LinthellBlackDiffPlugin(LinthellPlugin):
+    """Parser for output of command: 'black --diff --check [path,]*'.
+
+    Parser reformats the output to contain only required
+    information in one line: file path, line number, line of code.
+
+    It allows to use black with higher error restrictions than
+    `BlackCheck` does. Since BlackCheck suppresses any new error in
+    a file (if that file is covered by baseline) and this Plugin suppress error
+    on specific line of specific file.
+
+    # DEV NOTES
+
+    Example of output. Black used against code that misses empty line
+    before `def` and uses magic-comma but `*args` is not moved to spared line:
+        --- /home/user/package/module.py    2023-08-24 18:03:29.245834 +0000
+        +++ /home/user/package/module.py    2023-08-24 18:03:30.951316 +0000
+        @@ -1,3 +1,7 @@
+        import re
+
+        -def func(*args,):
+        +
+        +def func(
+        +    *args,
+        +):
+             pass
+
+    Most important part of the output is that there are two versions of files
+    where (excluding special lines that starts with @@, --- or +++):
+    - lines that start with ' ' are present in both versions
+    - lines that start with '-' are present in old version only
+    - lines that start with '+' are present in new version only
+
+    Parser memorize last know file path, parses line numbers
+    and increases that line number with each passed line.
+    That gives possibility to build output that contains all required parts
+    in one line: file path, line number, line of code.
+
+    Because of the format of output Parser is initialized in-process,
+    line by line, and that behavior may lead to partial-initialized problems.
+    Trying to keep code safe Parser validates all expected initialization
+    before any step so if it faces and unexpected state an error is raised
+    immediately preventing broken baseline or linter's output.
+    """
+
+    def __init__(self) -> None:  # noqa: D107
+        self.file_path: Optional[str] = None
+        self.old_file_version_line_number: Optional[int] = None
+        self.new_file_version_line_number: Optional[int] = None
+        self.errors: List[LinterError] = []
+
+    def parse(self, linter_output: str) -> List[LinterError]:
+        """Entry point for linthell.
+
+        :param linter_output: complete output of 'black --diff --check ...'
+        :return: List of found LinterError representing black-output
+
+        :raise BlackOutputInvalidError: on any unexpected output or it's order
+        """
+        for line in linter_output.splitlines():
+            if line.startswith(_FILE_PATH_SIGNS):
+                self._parse_file_path(line)
+            elif line.startswith(_LINE_NUMBER_SIGN):
+                self._parse_line_number(line)
+            elif line.startswith((_REMOVE_LINE_SIGN, _ADD_LINE_SIGN)):
+                file_version = (
+                    _FileVersion.OLD
+                    if line.startswith(_REMOVE_LINE_SIGN)
+                    else _FileVersion.NEW
+                )
+
+                self._append_errors(line=line, file_version=file_version)
+                self._incr_line_num(line=line, file_version=file_version)
+            elif line.startswith(_KEEP_LINE_SIGN):
+                self._incr_line_num(line=line, file_version=_FileVersion.OLD)
+                self._incr_line_num(line=line, file_version=_FileVersion.NEW)
+            else:
+                raise Exception(line)
+
+        return self.errors
+
+    def _parse_file_path(self, line: str) -> None:
+        """Parse file path from black output that starts with --- or +++."""
+        file_path_match = _FILE_PATH_PATTERN.fullmatch(line)
+        if not file_path_match:
+            raise BlackOutputInvalidFilePathLineError(line=line)
+
+        self.file_path = file_path_match.group('file_path')
+
+    def _parse_line_number(self, line: str) -> None:
+        """Parse line numbers from black output that starts with @."""
+        line_number_match = _LINE_NUMBER_PATTERN.fullmatch(line)
+        if not line_number_match:
+            raise BlackOutputInvalidLineNumberLineError(line=line)
+
+        self.old_file_version_line_number = int(
+            line_number_match.group('old_file_version_line_number')
+        )
+        self.new_file_version_line_number = int(
+            line_number_match.group('new_file_version_line_number')
+        )
+
+    def _append_errors(self, line: str, file_version: _FileVersion) -> None:
+        """Append errors.
+
+        LinterError created based on current state and passed argument
+        """
+        if file_version is _FileVersion.OLD:
+            line_number = self.old_file_version_line_number
+        elif file_version is _FileVersion.NEW:
+            line_number = self.new_file_version_line_number
+        else:
+            assert_never(file_version)
+
+        if self.file_path is None or line_number is None:
+            raise BlackOutputInvalidLineOrderError(line=line)
+
+        self.errors.append(
+            LinterError(
+                id_line=f'{self.file_path}:{line}',
+                error_message=f'{self.file_path}:{line_number}: {line}',
+            ),
+        )
+
+    def _incr_line_num(
+        self,
+        line: str,
+        file_version: _FileVersion,
+    ) -> None:
+        """Increment line number corresponding to file_version.
+
+        :param line: used only in case of error
+        :param file_version: affects which attribute would be incremented
+        """
+        if file_version is _FileVersion.OLD:
+            if self.old_file_version_line_number is None:
+                raise BlackOutputInvalidLineOrderError(line=line)
+            self.old_file_version_line_number += 1
+        elif file_version is _FileVersion.NEW:
+            if self.new_file_version_line_number is None:
+                raise BlackOutputInvalidLineOrderError(line=line)
+            self.new_file_version_line_number += 1
+        else:
+            assert_never(file_version)

--- a/linthell/plugins/black_diff.py
+++ b/linthell/plugins/black_diff.py
@@ -168,8 +168,6 @@ class LinthellBlackDiffPlugin(LinthellPlugin):
             elif line.startswith(_KEEP_LINE_SIGN):
                 self._incr_line_num(line=line, file_version=_FileVersion.OLD)
                 self._incr_line_num(line=line, file_version=_FileVersion.NEW)
-            else:
-                raise Exception(line)
 
         return self.errors
 

--- a/linthell/plugins/isort_diff.py
+++ b/linthell/plugins/isort_diff.py
@@ -1,3 +1,4 @@
+import os
 import re
 from enum import Enum
 from typing import List, Optional
@@ -130,6 +131,7 @@ class LinthellIsortDiffPlugin(LinthellPlugin):
     """
 
     def __init__(self) -> None:  # noqa: D107
+        self.base_path = os.getcwd()
         self.file_path: Optional[str] = None
         self.old_file_version_line_number: Optional[int] = None
         self.new_file_version_line_number: Optional[int] = None
@@ -169,7 +171,8 @@ class LinthellIsortDiffPlugin(LinthellPlugin):
         if not file_path_match:
             raise IsortOutputInvalidFilePathLineError(line=line)
 
-        self.file_path = file_path_match.group('file_path')
+        absolute_file_path = file_path_match.group('file_path')
+        self.file_path = os.path.relpath(absolute_file_path, self.base_path)
 
     def _parse_line_number(self, line: str) -> None:
         """Parse line numbers from isort output that starts with @."""

--- a/linthell/plugins/isort_diff.py
+++ b/linthell/plugins/isort_diff.py
@@ -1,0 +1,228 @@
+import re
+from enum import Enum
+from typing import List, Optional
+
+from typing_extensions import assert_never
+
+from linthell.plugins.base import LinthellPlugin
+from linthell.utils.types import LinterError
+
+_OLD_VERSION_FILE_PATH_SIGN = '--- '
+_NEW_VERSION_FILE_PATH_SIGN = '+++ '
+_FILE_PATH_SIGNS = (_OLD_VERSION_FILE_PATH_SIGN, _NEW_VERSION_FILE_PATH_SIGN)
+_FILE_PATH_PATTERN = re.compile(r'(?:-{3}|\+{3})\s(?P<file_path>[\w/.-]+).*')
+"""Example: --- package/module.py:before   2023-06-11 22:35:28.465518"""
+_LINE_NUMBER_SIGN = '@'
+_LINE_NUMBER_PATTERN = re.compile(
+    r'@@ -(?P<old_file_version_line_number>\d+),\d+'
+    r' \+(?P<new_file_version_line_number>\d+),\d+ @@'
+)
+"""Example: @@ -10,20 +10,20 @@"""
+_REMOVE_LINE_SIGN = '-'
+"""Example: -    import b, a"""
+_ADD_LINE_SIGN = '+'
+"""Example: +    import a, b"""
+_KEEP_LINE_SIGN = ' '
+"""Example:      import a, b"""
+
+
+class _FileVersion(Enum):
+    """Enumeration of file versions represented in isort output."""
+
+    OLD = 'old'
+    NEW = 'new'
+
+
+class IsortOutputInvalidError(Exception):
+    """Base error of invalid isort-diff output.
+
+    Used to encapsulate logic of building an error message.
+    Allows to set `DEFAULT_MSG` for subclasses.
+    """
+
+    DEFAULT_MSG: str = 'no detail'
+
+    def __init__(self, line: str, msg: Optional[str] = None) -> None:
+        """Initialize exception instance.
+
+        :param line: line of black-diff output.
+        :param msg: verbose message of error.
+                    If not passed `self.DEFAULT_MSG` is used.
+        """
+        self.line = line
+        self.msg = msg or self.DEFAULT_MSG
+
+    def __str__(self):
+        return f'Invalid isort-diff output ({self.msg}): {self.line}'
+
+
+class IsortOutputInvalidFilePathLineError(IsortOutputInvalidError):
+    """Error of isort-diff output. Invalid line with file path.
+
+    Raised if line expected to contain file path but doesn't match pattern.
+    """
+
+    DEFAULT_MSG = (
+        'expected line to contain file path '
+        'but it does not match expected pattern'
+    )
+
+
+class IsortOutputInvalidLineNumberLineError(IsortOutputInvalidError):
+    """Error of isort-diff output. Invalid line with line numbers.
+
+    Raised if line expected to contain line numbers but doesn't match pattern.
+    """
+
+    DEFAULT_MSG = (
+        'expected line to contain line number '
+        'but it does not match expected pattern'
+    )
+
+
+class IsortOutputInvalidLineOrderError(IsortOutputInvalidError):
+    """Error of isort-diff output. Invalid line order.
+
+    Raised if expected to face lines with file path and line numbers before
+    current in-process line.
+    """
+
+    DEFAULT_MSG = (
+        'expected lines with file path and line number before lines with code'
+    )
+
+
+class LinthellIsortDiffPlugin(LinthellPlugin):
+    """Parser for output of command: 'isort --diff --check-only [path,]*'.
+
+    Parser reformats the output to contain only required
+    information in one line: file path, line number, line of code.
+
+    # DEV NOTES
+
+    Example of output:
+        --- /home/user/package/module.py:before     2023-08-27 19:16:45.692641
+        +++ /home/user/package/module.py:after      2023-08-27 19:16:53.009897
+        @@ -1,3 +1,3 @@
+        +import a
+         import b
+        -import a
+        -from c import b, a
+        +from c import a, b
+        Skipped 2 files
+
+    Most important part of the output is that there are two versions of files
+    where (excluding special lines that starts with @@, --- or +++):
+    - lines that start with ' ' are present in both versions
+    - lines that start with '-' are present in old version only
+    - lines that start with '+' are present in new version only
+
+    Parser memorize last know file path, parses line numbers
+    and increases that line number with each passed line.
+    That gives possibility to build output that contains all required parts
+    in one line: file path, line number, line of code.
+
+    Because of the format of output Parser is initialized in-process,
+    line by line, and that behavior may lead to partial-initialized problems.
+    Trying to keep code safe Parser validates all expected initialization
+    before any step so if it faces and unexpected state an error is raised
+    immediately preventing broken baseline or linter's output.
+    """
+
+    def __init__(self) -> None:  # noqa: D107
+        self.file_path: Optional[str] = None
+        self.old_file_version_line_number: Optional[int] = None
+        self.new_file_version_line_number: Optional[int] = None
+        self.errors: List[LinterError] = []
+
+    def parse(self, linter_output: str) -> List[LinterError]:
+        """Entry point for linthell.
+
+        :param linter_output: complete output of 'isort --diff --check-only'
+        :return: List of found LinterError representing isort-output
+
+        :raise IsortOutputInvalidError: on any unexpected output or it's order
+        """
+        for line in linter_output.splitlines():
+            if line.startswith(_FILE_PATH_SIGNS):
+                self._parse_file_path(line)
+            elif line.startswith(_LINE_NUMBER_SIGN):
+                self._parse_line_number(line)
+            elif line.startswith((_REMOVE_LINE_SIGN, _ADD_LINE_SIGN)):
+                file_version = (
+                    _FileVersion.OLD
+                    if line.startswith(_REMOVE_LINE_SIGN)
+                    else _FileVersion.NEW
+                )
+
+                self._append_errors(line=line, file_version=file_version)
+                self._incr_line_num(line=line, file_version=file_version)
+            elif line.startswith(_KEEP_LINE_SIGN):
+                self._incr_line_num(line=line, file_version=_FileVersion.OLD)
+                self._incr_line_num(line=line, file_version=_FileVersion.NEW)
+
+        return self.errors
+
+    def _parse_file_path(self, line: str) -> None:
+        """Parse file path from isort output that starts with --- or +++."""
+        file_path_match = _FILE_PATH_PATTERN.fullmatch(line)
+        if not file_path_match:
+            raise IsortOutputInvalidFilePathLineError(line=line)
+
+        self.file_path = file_path_match.group('file_path')
+
+    def _parse_line_number(self, line: str) -> None:
+        """Parse line numbers from isort output that starts with @."""
+        line_number_match = _LINE_NUMBER_PATTERN.fullmatch(line)
+        if not line_number_match:
+            raise IsortOutputInvalidLineNumberLineError(line=line)
+
+        self.old_file_version_line_number = int(
+            line_number_match.group('old_file_version_line_number')
+        )
+        self.new_file_version_line_number = int(
+            line_number_match.group('new_file_version_line_number')
+        )
+
+    def _append_errors(self, line: str, file_version: _FileVersion) -> None:
+        """Append errors.
+
+        LinterError created based on current state and passed argument
+        """
+        if file_version is _FileVersion.OLD:
+            line_number = self.old_file_version_line_number
+        elif file_version is _FileVersion.NEW:
+            line_number = self.new_file_version_line_number
+        else:
+            assert_never(file_version)
+
+        if self.file_path is None or line_number is None:
+            raise IsortOutputInvalidLineOrderError(line=line)
+
+        self.errors.append(
+            LinterError(
+                id_line=f'{self.file_path}:{line}',
+                error_message=f'{self.file_path}:{line_number}: {line}',
+            ),
+        )
+
+    def _incr_line_num(
+        self,
+        line: str,
+        file_version: _FileVersion,
+    ) -> None:
+        """Increment line number corresponding to file_version.
+
+        :param line: used only in case of error
+        :param file_version: affects which attribute would be incremented
+        """
+        if file_version is _FileVersion.OLD:
+            if self.old_file_version_line_number is None:
+                raise IsortOutputInvalidLineOrderError(line=line)
+            self.old_file_version_line_number += 1
+        elif file_version is _FileVersion.NEW:
+            if self.new_file_version_line_number is None:
+                raise IsortOutputInvalidLineOrderError(line=line)
+            self.new_file_version_line_number += 1
+        else:
+            assert_never(file_version)

--- a/linthell/plugins/isort_diff.py
+++ b/linthell/plugins/isort_diff.py
@@ -14,8 +14,8 @@ _FILE_PATH_PATTERN = re.compile(r'(?:-{3}|\+{3})\s(?P<file_path>[\w/.-]+).*')
 """Example: --- package/module.py:before   2023-06-11 22:35:28.465518"""
 _LINE_NUMBER_SIGN = '@'
 _LINE_NUMBER_PATTERN = re.compile(
-    r'@@ -(?P<old_file_version_line_number>\d+),\d+'
-    r' \+(?P<new_file_version_line_number>\d+),\d+ @@'
+    r'@@ -(?P<old_file_version_line_number>\d+)(,\d+)?'
+    r' \+(?P<new_file_version_line_number>\d+)(,\d+)? @@'
 )
 """Example: @@ -10,20 +10,20 @@"""
 _REMOVE_LINE_SIGN = '-'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,11 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.pydocstyle]
-ignore = ["D100", "D104", "D213", "D203", "D407", "D413"]
+ignore = ["D100", "D104", "D105", "D213", "D203", "D407", "D413"]
 
 [tool.poetry.plugins."linthell.plugins"]
 black-check = "linthell.plugins.black_check:LinthellBlackCheckPlugin"
+black-diff = "linthell.plugins.black_diff:LinthellBlackDiffPlugin"
 flake8 = "linthell.plugins.flake8:LinthellFlake8Plugin"
 pydocstyle = "linthell.plugins.pydocstyle:LinthellPydocstylePlugin"
 mypy = "linthell.plugins.mypy:LinthellMypyPlugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ignore = ["D100", "D104", "D105", "D213", "D203", "D407", "D413"]
 [tool.poetry.plugins."linthell.plugins"]
 black-check = "linthell.plugins.black_check:LinthellBlackCheckPlugin"
 black-diff = "linthell.plugins.black_diff:LinthellBlackDiffPlugin"
+isort-diff = "linthell.plugins.isort_diff:LinthellIsortDiffPlugin"
 flake8 = "linthell.plugins.flake8:LinthellFlake8Plugin"
 pydocstyle = "linthell.plugins.pydocstyle:LinthellPydocstylePlugin"
 mypy = "linthell.plugins.mypy:LinthellMypyPlugin"


### PR DESCRIPTION
Added smart plugins to use with `black --check --diff` and `isort --check-only --diff`.

# How to test it

```bash
mkdir linthell_black_isort_diff_test && cd $_ && git init
python3 -m venv venv && . venv/bin/activate
python -m pip install --no-cache black isort pre-commit 'linthell @ git+https://github.com/discrimy/linthell.git@0c4fdfe416369757a398f1d4ac7c737f3efd1306'
touch t.py linthell_black_baseline.txt linthell_isort_baseline.txt .pre-commit-config.yaml
git add t.py && git commit -m "init commit"
```

Add broken code to t.py:

```python
import b
import a
from _ import b, a

def func(arg,):
    pass

```
Add `pre-commit` config:

```yaml
repos:
  - repo: local
    hooks:
      - id: isort
        name: isort
        language: system
        entry: isort --check-only --diff 
        types:  [python]
  - repo: local
    hooks:
      - id: linthell_isort
        name: linthell over isort
        language: system
        entry: linthell pre-commit lint -p isort-diff -b linthell_isort_baseline.txt --linter-command "isort --check-only --diff"
        types:  [python]
  - repo: local
    hooks:
      - id: black
        name: black
        language: system
        entry: black --check --diff
        types:  [python]
  - repo: local
    hooks:
      - id: linthell_black
        name: linthell over black
        language: system
        entry: linthell pre-commit lint -p black-diff -b linthell_black_baseline.txt --linter-command "black --check --diff"
        types:  [python]
```

run `pre-commit run --all` to see difference in outputs:
```text
isort....................................................................Failed
- hook id: isort
- exit code: 1

ERROR: /home/rows/py_dev/linthell_black_isort_diff_test/t.py Imports are incorrectly sorted and/or formatted.
--- /home/rows/py_dev/linthell_black_isort_diff_test/t.py:before        2023-08-28 19:27:10.545735
+++ /home/rows/py_dev/linthell_black_isort_diff_test/t.py:after 2023-08-28 19:27:24.559449
@@ -1,6 +1,7 @@
+import a
 import b
-import a
-from _ import b, a
+from _ import a, b
+
 
 def func(arg,):
     pass

linthell over isort......................................................Failed
- hook id: linthell_isort
- exit code: 1

t.py:1: +import a
t.py:2: -import a
t.py:3: -from _ import b, a
t.py:3: +from _ import a, b
t.py:4: +

black....................................................................Failed
- hook id: black
- exit code: 1

--- t.py        2023-08-28 16:27:10.545735+00:00
+++ t.py        2023-08-28 16:27:24.972181+00:00
@@ -1,6 +1,9 @@
 import b
 import a
 from _ import b, a
 
-def func(arg,):
+
+def func(
+    arg,
+):
     pass
would reformat t.py

Oh no! 💥 💔 💥
1 file would be reformatted.

linthell over black......................................................Failed
- hook id: linthell_black
- exit code: 1

t.py:5: -def func(arg,):
t.py:5: +
t.py:6: +def func(
t.py:7: +    arg,
t.py:8: +):
```

build `baselines`:
```bash
linthell pre-commit baseline -b linthell_isort_baseline.txt -p isort-diff --hook-name "linthell over isort" --linter-command "isort --check-only --diff"
linthell pre-commit baseline -b linthell_black_baseline.txt -p black-diff --hook-name "linthell over black" --linter-command "black --check --diff"
```
Run linhell to check that all errors are suppressed:
```bash
pre-commit run linthell_isort --all
pre-commit run linthell_black --all
```
Check baselines:
```python
# isort
t.py:+
t.py:+from _ import a, b
t.py:+import a
t.py:-from _ import b, a
t.py:-import a
# black
t.py:+
t.py:+    arg,
t.py:+):
t.py:+def func(
t.py:-def func(arg,):
```

# Code duplicate

Both Plugins has the same implementation with only different names and doc-strings, it would be fair to ask "maybe code could be reused?", but i was trying to prepare for cases when only one plugin will change the structure of output and than `linthell` will forced to adapt for new rules. If `linthell` would face it with both plugins reuses "base" code it would be a mess with `if-statements` or inheritance. Cognitive and maintain complexities would be increased significantly, and don't forget that plugin interfaced may be reused in other external plugins so `linthell` would try to make only backward-compatible changes.